### PR TITLE
enhancement: stylize code

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -153,9 +153,8 @@ func appendToNonce(nonce []byte, segmentIdx uint32, isLast bool) {
 	nonce[l-4] = byte(segmentIdx >> 8)
 	nonce[l-3] = byte(segmentIdx >> 16)
 	nonce[l-2] = byte(segmentIdx >> 24)
+	nonce[l-1] = 0
 	if isLast {
 		nonce[l-1] = 1
-	} else {
-		nonce[l-1] = 0
 	}
 }

--- a/decrypt.go
+++ b/decrypt.go
@@ -7,8 +7,9 @@ import (
 	"crypto/cipher"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/hkdf"
 	"io"
+
+	"golang.org/x/crypto/hkdf"
 )
 
 // DecryptingReadSeeker reads ciphertext and returns plaintext.


### PR DESCRIPTION
- Add verbose errors to `(*CiphertextHeader).MarshalTo/UnmarshalFrom`
- Fix imports order
- Get rid of frustrating `else` :)